### PR TITLE
update: entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,6 +51,7 @@ echo -e "[flake8] ${SUCCESS_COLOR}success${RESET}"
 set +e
 TIME_A=`date +%s`
 echo -e "\n${VERSION_COLOR}$(mypy --version)${RESET}"
+echo "y" | mypy --install-types
 for file_name in `find $@`; do
     file_ext=`basename $file_name | sed 's/^.*\.\([^\.]*\)$/\1/'`
     if [ -z $file_ext ] || [ "py" != $file_ext ];


### PR DESCRIPTION
# overview
fiexed.

```
error: Library stubs not installed for "requests" (or incompatible with Python 3.9)
note: Hint: "python3 -m pip install types-requests"
note: (or run "mypy --install-types" to install all missing stub packages)
note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
error: Library stubs not installed for "requests.models" (or incompatible with Python 3.9)
error: Returning Any from function declared to return "str"
Found 3 errors in 1 file (checked 1 source file)
```